### PR TITLE
Add compatibility with Algolia v2 client

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=7.1.0",
-        "laravel/nova": "*"
+        "php": ">=7.1.0"
     },
     "require-dev": {
     },

--- a/src/Algolia.php
+++ b/src/Algolia.php
@@ -2,17 +2,20 @@
 
 namespace NicolasBeauvais\NovaAlgoliaCard;
 
+use AlgoliaSearch\Client as AlgoliaClientV1;
+use Algolia\AlgoliaSearch\SearchClient as AlgoliaClientV2;
+
 class Algolia
 {
     private $useClientV2 = true;
 
     public function __construct()
     {
-        if (class_exists('AlgoliaSearch\Client') {
-            $this->client = new AlgoliaSearch\Client(config('scout.algolia.id'), config('scout.algolia.secret'));
+        if (class_exists('AlgoliaSearch\Client')) {
+            $this->client = new AlgoliaClientV1(config('scout.algolia.id'), config('scout.algolia.secret'));
             $this->useClientV2 = false;
         } else {
-            $this->client = Algolia\AlgoliaSearch\SearchClient::create(config('scout.algolia.id'), config('scout.algolia.secret'));
+            $this->client = AlgoliaClientV2::create(config('scout.algolia.id'), config('scout.algolia.secret'));
         }
     }
 
@@ -44,8 +47,8 @@ class Algolia
 
         return collect($indexes['items'])->where('name', $index)->sum('entries');
     }
-            
-    private function listIndexes() 
+
+    private function listIndexes()
     {
         if ($this->useClientV2) {
             return $this->client->listIndices();

--- a/src/Algolia.php
+++ b/src/Algolia.php
@@ -2,13 +2,18 @@
 
 namespace NicolasBeauvais\NovaAlgoliaCard;
 
-use AlgoliaSearch\Client;
-
 class Algolia
 {
+    private $useClientV2 = true;
+
     public function __construct()
     {
-        $this->client = new Client(config('scout.algolia.id'), config('scout.algolia.secret'));
+        if (class_exists('AlgoliaSearch\Client') {
+            $this->client = new AlgoliaSearch\Client(config('scout.algolia.id'), config('scout.algolia.secret'));
+            $this->useClientV2 = false;
+        } else {
+            $this->client = Algolia\AlgoliaSearch\SearchClient::create(config('scout.algolia.id'), config('scout.algolia.secret'));
+        }
     }
 
     public function getEntries(string $index = null) : ?int
@@ -20,7 +25,7 @@ class Algolia
 
     public function getAllEntries() : ?int
     {
-        $indexes = $this->client->listIndexes();
+        $indexes = $this->listIndexes();
 
         if (!isset($indexes['items'])) {
             return null;
@@ -31,12 +36,21 @@ class Algolia
 
     public function getEntriesOfIndex(string $index) : ?int
     {
-        $indexes = $this->client->listIndexes();
+        $indexes = $this->listIndexes();
 
         if (!isset($indexes['items'])) {
             return null;
         }
 
         return collect($indexes['items'])->where('name', $index)->sum('entries');
+    }
+            
+    private function listIndexes() 
+    {
+        if ($this->useClientV2) {
+            return $this->client->listIndices();
+        } else {
+            return $this->client->listIndexes();
+        }
     }
 }


### PR DESCRIPTION
This package is still compatible with v1 and v2 of the Algolia client. Fix #2 

The instantiation of the client changed and `listIndexes` was renamed to `listIndices`.

Ideally, I want to run the test with both v1 and v2 (I haven't done it yet)

Note: I was the main developer working on the v2 but I don't work on it anymore.